### PR TITLE
Add permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 ## About ##
 This paper plugin adds compatibility for the mod by the same name [Armor Poser](https://www.curseforge.com/minecraft/mc-mods/armor-poser).
 
+## Permissions ##
+When the `requirePermissions` config option is set to `true`, these permissions can be used
+
+| Permission        | Description                               |
+|-------------------|-------------------------------------------|
+| armorposer.use    | Allows a player to open the GUI           |
+| armorposer.resize | Allows a player to resize the Armor Stand |
+
 ## License ##
 * Armor Poser - Plugin licensed under the MIT license
   - (c) 2024 Mrbysco

--- a/src/main/java/com/mrbysco/armorposer/ArmorPoserPlugin.java
+++ b/src/main/java/com/mrbysco/armorposer/ArmorPoserPlugin.java
@@ -15,7 +15,11 @@ public final class ArmorPoserPlugin extends JavaPlugin {
 	public static Plugin Plugin;
 	public final FileConfiguration config = getConfig();
 
+	public static final String USE_PERMISSION = "armorposer.use";
+	public static final String RESIZE_PERMISSION = "armorposer.resize";
+
 	public static boolean enableConfigGui;
+	public static boolean requirePermissions;
 	public static boolean restrictResizeToOP;
 	public static List<String> resizeWhitelist = new ArrayList<>();
 
@@ -37,12 +41,14 @@ public final class ArmorPoserPlugin extends JavaPlugin {
 	 */
 	private void setupConfig() {
 		config.addDefault("enableConfigGui", true);
+		config.addDefault("requirePermissions", false);
 		config.addDefault("restrictResizeToOP", false);
 		config.addDefault("resizeWhitelist", List.of(""));
 		config.options().copyDefaults(true);
 		saveConfig();
 
 		enableConfigGui = config.getBoolean("enableConfigGui");
+		requirePermissions = config.getBoolean("requirePermissions");
 		restrictResizeToOP = config.getBoolean("restrictResizeToOP");
 		resizeWhitelist = config.getStringList("resizeWhitelist");
 	}

--- a/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
+++ b/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
@@ -30,8 +30,8 @@ public class EventHandlers implements Listener {
 	}
 
 	private boolean canUseGUI(Player player) {
-		if(!ArmorPoserPlugin.enableConfigGui) return false;
-		if(!ArmorPoserPlugin.requirePermissions) return true;
+		if (!ArmorPoserPlugin.enableConfigGui) return false;
+		if (!ArmorPoserPlugin.requirePermissions) return true;
 		return player.hasPermission(ArmorPoserPlugin.USE_PERMISSION);
 	}
 

--- a/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
+++ b/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
@@ -17,7 +17,7 @@ public class EventHandlers implements Listener {
 	public void onInteract(PlayerInteractAtEntityEvent event) {
 		Player player = event.getPlayer();
 		Entity entity = event.getRightClicked();
-		if (entity instanceof ArmorStand armorStand && player.isSneaking() && ArmorPoserPlugin.enableConfigGui) {
+		if (entity instanceof ArmorStand armorStand && player.isSneaking() && canUseGUI(player)) {
 			if (event.getHand() == EquipmentSlot.HAND) {
 				ByteArrayDataOutput out = ByteStreams.newDataOutput();
 				out.writeInt(armorStand.getEntityId());
@@ -28,4 +28,11 @@ public class EventHandlers implements Listener {
 			event.setCancelled(true);
 		}
 	}
+
+	private boolean canUseGUI(Player player) {
+		if(!ArmorPoserPlugin.enableConfigGui) return false;
+		if(!ArmorPoserPlugin.requirePermissions) return true;
+		return player.hasPermission(ArmorPoserPlugin.USE_PERMISSION);
+	}
+
 }

--- a/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
+++ b/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
@@ -9,33 +9,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 public class EventHandlers implements Listener {
-	@EventHandler
-	public void onInteract(PlayerInteractEntityEvent event) {
-		Player player = event.getPlayer();
-		Entity entity = event.getRightClicked();
-		if (entity instanceof ArmorStand armorStand) {
-			if (ArmorPoserPlugin.enableConfigGui && player.isSneaking()) {
-				if (event.getHand() == EquipmentSlot.HAND) {
-					ByteArrayDataOutput out = ByteStreams.newDataOutput();
-					out.writeInt(armorStand.getEntityId());
-					ArmorPoserPlugin.Plugin.getServer().getMessenger().registerOutgoingPluginChannel(ArmorPoserPlugin.Plugin, "armorposer:screen_packet");
-					player.sendPluginMessage(ArmorPoserPlugin.Plugin, "armorposer:screen_packet", out.toByteArray());
-					ArmorPoserPlugin.Plugin.getServer().getMessenger().unregisterOutgoingPluginChannel(ArmorPoserPlugin.Plugin, "armorposer:screen_packet");
-				}
-				event.setCancelled(true);
-			}
-		}
-	}
 
 	@EventHandler
 	public void onInteract(PlayerInteractAtEntityEvent event) {
 		Player player = event.getPlayer();
 		Entity entity = event.getRightClicked();
-		if (entity instanceof ArmorStand armorStand && player.isSneaking()) {
+		if (entity instanceof ArmorStand armorStand && player.isSneaking() && ArmorPoserPlugin.enableConfigGui) {
 			if (event.getHand() == EquipmentSlot.HAND) {
 				ByteArrayDataOutput out = ByteStreams.newDataOutput();
 				out.writeInt(armorStand.getEntityId());

--- a/src/main/java/com/mrbysco/armorposer/handler/SyncHandler.java
+++ b/src/main/java/com/mrbysco/armorposer/handler/SyncHandler.java
@@ -136,11 +136,11 @@ public class SyncHandler implements PluginMessageListener {
 	}
 
 	public static boolean canResize(Player player) {
-		if(ArmorPoserPlugin.requirePermissions) {
+		if (ArmorPoserPlugin.requirePermissions) {
 			return player.hasPermission(ArmorPoserPlugin.RESIZE_PERMISSION);
 		}
 		if (ArmorPoserPlugin.restrictResizeToOP && player != null) {
-			if (ArmorPoserPlugin.resizeWhitelist.contains(player.getName())){
+			if (ArmorPoserPlugin.resizeWhitelist.contains(player.getName())) {
 				return true;
 			}
 			return player.isOp();

--- a/src/main/java/com/mrbysco/armorposer/handler/SyncHandler.java
+++ b/src/main/java/com/mrbysco/armorposer/handler/SyncHandler.java
@@ -2,7 +2,6 @@ package com.mrbysco.armorposer.handler;
 
 import com.mrbysco.armorposer.ArmorPoserPlugin;
 import io.netty.buffer.Unpooled;
-import io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -137,6 +136,9 @@ public class SyncHandler implements PluginMessageListener {
 	}
 
 	public static boolean canResize(Player player) {
+		if(ArmorPoserPlugin.requirePermissions) {
+			return player.hasPermission(ArmorPoserPlugin.RESIZE_PERMISSION);
+		}
 		if (ArmorPoserPlugin.restrictResizeToOP && player != null) {
 			if (ArmorPoserPlugin.resizeWhitelist.contains(player.getName())){
 				return true;


### PR DESCRIPTION
This PR adds the ability to restrict opening the GUI or resizing an armour stand using the Bukkit permission system.

It adds two permissions: `armorposer.use` and `armorposer.resize`.
There is a new config option, `requirePermissions`, which dictates whether permissions are required.
The permissions are listed and explained in the README.

4bce14ecd333998f4bb77b885fd8f67bbd81e2a1 also removes the redundant listener for `PlayerInteractEntityEvent`, since [only PlayerInteractAtEntityEvent gets fired for armour stands](https://jd.papermc.io/paper/1.21.4/org/bukkit/event/player/PlayerInteractAtEntityEvent.html).

Demonstration using [LuckPerms](https://luckperms.net):

https://github.com/user-attachments/assets/e266efdf-1c66-4445-988b-9ab71319aaf7