### PR TITLE
Add support for PaperMC 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'java'
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.18"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.19"
     id("xyz.jpenilla.run-paper") version "3.0.2"
 }
 
 group = 'com.mrbysco'
-version = "${version}"
+version = plugin_version
 base {
     archivesName = "${mod_name}"
 }
@@ -31,11 +31,13 @@ tasks {
     }
 }
 
+paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.getMOJANG_PRODUCTION()
+
 processResources {
-    def props = [version: version]
+    def props = [plugin_version: plugin_version]
     getInputs().properties(props)
     filteringCharset("UTF-8")
-    filesMatching("plugin.yml") {
+    filesMatching(["plugin.yml", "paper-plugin.yml"]) {
         expand(props)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Base info
-mc_version=1.21.10
-paper_version=1.21.10-R0.1-SNAPSHOT
-paperweight_version=1.21.10-R0.1-SNAPSHOT
+mc_version=1.21.11
+paper_version=1.21.11-R0.1-SNAPSHOT
+paperweight_version=1.21.11-R0.1-SNAPSHOT
 
 #Publishing
 mod_name=ArmorPoser-Plugin
 
 # Version
-version=1.3.2
+plugin_version=1.3.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -5,3 +5,4 @@ api-version: '1.21.11'
 author: "Mrbysco"
 description: "A paper plugin that allows clients to use Armor Poser to pose armor stands"
 website: "https://www.curseforge.com/minecraft/bukkit-plugins/armor-poser-plugin"
+folia-supported: true


### PR DESCRIPTION
- Update to support 1.21.11
- Dependency update : Gradle to v9.2.1 / API to 1.21.11 / UserDev to latest 2.0.0-beta.19
- Also fully "converted" the plugin for paper support (so it's considered as a Paper plugin on startup and not "bukkit" anymore, purely cosmetic change)

Change only tested on PaperMC 1.21.11