### PR TITLE
Respect antigriefing plugins

### DIFF
--- a/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
+++ b/src/main/java/com/mrbysco/armorposer/handler/EventHandlers.java
@@ -7,13 +7,14 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 public class EventHandlers implements Listener {
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onInteract(PlayerInteractAtEntityEvent event) {
 		Player player = event.getPlayer();
 		Entity entity = event.getRightClicked();


### PR DESCRIPTION
Antigriefing plugins like WorldGuard may cancel player's events if player is not supposed to interact here. But Armor Poser Plugin opens GUI even if interaction event was cancelled that allows user to edit armor stands anyways.

Solution: 
* Change event listener priority to `HIGHEST` (means Armor Stand Plugin will receive event as last as possible) and `ignoreCancelled` to `true`

Tested on Paper 1.21.11-92-main, WorldGuard 7.0.15
