### PR TITLE
Implement move permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ When the `requirePermissions` config option is set to `true`, these permissions 
 |-------------------|-------------------------------------------|
 | armorposer.use    | Allows a player to open the GUI           |
 | armorposer.resize | Allows a player to resize the Armor Stand |
+| armorposer.lock   | Allows a player to lock the Armor Stand   |
+| armorposer.move   | Allows a player to move the Armor Stand   |
 
 ## License ##
 * Armor Poser - Plugin licensed under the MIT license

--- a/src/main/java/com/mrbysco/armorposer/ArmorPoserPlugin.java
+++ b/src/main/java/com/mrbysco/armorposer/ArmorPoserPlugin.java
@@ -23,6 +23,7 @@ public final class ArmorPoserPlugin extends JavaPlugin {
 	public static final String USE_PERMISSION = "armorposer.use";
 	public static final String RESIZE_PERMISSION = "armorposer.resize";
 	public static final String LOCK_PERMISSION = "armorposer.lock";
+	public static final String MOVE_PERMISSION = "armorposer.move";
 
 	public static boolean enableConfigGui;
 	public static boolean requirePermissions;
@@ -36,6 +37,11 @@ public final class ArmorPoserPlugin extends JavaPlugin {
 	public static boolean canUse(Player player) {
 		if (!requirePermissions) return true;
 		return player.hasPermission(ArmorPoserPlugin.USE_PERMISSION);
+	}
+
+	public static boolean canMove(Player player) {
+		if (!requirePermissions) return true;
+		return player.hasPermission(ArmorPoserPlugin.MOVE_PERMISSION);
 	}
 
 	@Override

--- a/src/main/java/com/mrbysco/armorposer/handler/SyncHandler.java
+++ b/src/main/java/com/mrbysco/armorposer/handler/SyncHandler.java
@@ -103,7 +103,7 @@ public class SyncHandler implements PluginMessageListener {
 				double x = movePos.x();
 				double y = movePos.y();
 				double z = movePos.z();
-				if (x != 0 || y != 0 || z != 0) {
+				if ((x != 0 || y != 0 || z != 0) && ArmorPoserPlugin.canMove(player)) {
 					float oldYaw = armorStand.getYaw();
 					float oldPitch = armorStand.getPitch();
 					if (ArmorPoserPlugin.isFolia()) {


### PR DESCRIPTION
It's better late than never 😅

Here is implementation of pemission node for moving armor stands. 
Players can scary other players with moving stands. so I decided to implement this permission.

I've build against 26.2, but implementation (and this PR) remains the same from 1.21.11 up to 26.2